### PR TITLE
Map well-known types for method signatures too

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -531,37 +531,46 @@ impl <'a> CodeGenerator<'a> {
         let comments = Comments::from_location(self.location());
 
         self.path.push(2);
-        let methods = service.method
-                             .into_iter()
-                             .enumerate()
-                             .map(|(idx, mut method)| {
-                                 debug!("  method: {:?}", method.name());
-                                 self.path.push(idx as i32);
-                                 let comments = Comments::from_location(self.location());
-                                 self.path.pop();
+        let methods = service
+            .method
+            .into_iter()
+            .enumerate()
+            .map(|(idx, mut method)| {
+                debug!("  method: {:?}", method.name());
+                self.path.push(idx as i32);
+                let comments = Comments::from_location(self.location());
+                self.path.pop();
 
-                                 let name = method.name.take().unwrap();
-                                 let input_proto_type = method.input_type.take().unwrap();
-                                 let output_proto_type = method.output_type.take().unwrap();
-                                 let input_type = self.resolve_ident(&input_proto_type);
-                                 let output_type = self.resolve_ident(&output_proto_type);
-                                 let client_streaming = method.client_streaming();
-                                 let server_streaming = method.server_streaming();
+                let name = method.name.take().unwrap();
+                let input_proto_type = method.input_type.take().unwrap();
+                let output_proto_type = method.output_type.take().unwrap();
+                let input_type = if let Some(ty) = self.known_type(&input_proto_type) {
+                    ty.to_string()
+                } else {
+                    self.resolve_ident(&input_proto_type)
+                };
+                let output_type = if let Some(ty) = self.known_type(&output_proto_type) {
+                    ty.to_string()
+                } else {
+                    self.resolve_ident(&output_proto_type)
+                };
+                let client_streaming = method.client_streaming();
+                let server_streaming = method.server_streaming();
 
-                                 Method {
-                                     name: to_snake(&name),
-                                     proto_name: name,
-                                     comments,
-                                     input_type,
-                                     output_type,
-                                     input_proto_type,
-                                     output_proto_type,
-                                     options: method.options.unwrap_or_default(),
-                                     client_streaming,
-                                     server_streaming,
-                                 }
-                             })
-                             .collect();
+                Method {
+                    name: to_snake(&name),
+                    proto_name: name,
+                    comments,
+                    input_type,
+                    output_type,
+                    input_proto_type,
+                    output_proto_type,
+                    options: method.options.unwrap_or_default(),
+                    client_streaming,
+                    server_streaming,
+                }
+            })
+            .collect();
         self.path.pop();
 
         let service = Service {


### PR DESCRIPTION
We did not map well-known types in method signatures over. This PR intends to fix that, temporarily.

Note that the upstream has fixed this issue, though the APIs are different.